### PR TITLE
Add CakeAliasCategory

### DIFF
--- a/Cake.BenchmarkDotNet/BenchmarkDotNetAliases.cs
+++ b/Cake.BenchmarkDotNet/BenchmarkDotNetAliases.cs
@@ -11,6 +11,7 @@ using Cake.Core.Annotations;
 using Cake.Core.Diagnostics;
 using Perfolizer.Mathematics.Thresholds;
 
+[CakeAliasCategory("BenchmarkDotNet")]
 public static class BenchmarkDotNetAliases
 {
     [CakeMethodAlias]


### PR DESCRIPTION
Add CakeAliasCategory which is used to show aliases for the addin on the Cake website (https://cakebuild.net/extensions/cake-benchmarkdotnet/).