### PR TITLE
Enable comparing NuGet package version results.

### DIFF
--- a/Cake.BenchmarkDotNet/BenchmarkDotNetAliases.cs
+++ b/Cake.BenchmarkDotNet/BenchmarkDotNetAliases.cs
@@ -42,7 +42,9 @@ public static class BenchmarkDotNetAliases
     {
         context.Log.Write(Verbosity.Normal, LogLevel.Information, $"Comparing artifacts from '{benchmarkDotNetArtifactsDirectory}'.");
 
-        var nuGetCompareFinalResult = new NuGetComparer(settings.TestThresholdPercentage).Compare(benchmarkDotNetArtifactsDirectory, settings.Filters);
+        var nuGetCompareFinalResult = new NuGetComparer(settings.TestThresholdPercentage)
+            .Compare(benchmarkDotNetArtifactsDirectory, settings.TestThresholdPercentage, settings.Filters);
+
         Print(context, "trx", nuGetCompareFinalResult, settings.TrxFilePath);
         Print(context, "html", nuGetCompareFinalResult, settings.HtmlFilePath);
         Print(context, "md", nuGetCompareFinalResult, settings.MarkdownFilePath);

--- a/Cake.BenchmarkDotNet/Cake.BenchmarkDotNet.csproj
+++ b/Cake.BenchmarkDotNet/Cake.BenchmarkDotNet.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="2.2.0" />
+    <PackageReference Include="CsvHelper" Version="28.0.1" />
     <PackageReference Include="MarkdownLog.NS20" Version="0.10.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Perfolizer" Version="0.2.1" />

--- a/Cake.BenchmarkDotNet/NuGetComparison/BenchmarkDotNetNuGetCompareSettings.cs
+++ b/Cake.BenchmarkDotNet/NuGetComparison/BenchmarkDotNetNuGetCompareSettings.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Cake.BenchmarkDotNet.NuGetComparison
+{
+    public class BenchmarkDotNetNuGetCompareSettings
+    {
+        public IEnumerable<string> Filters { get; set; } = Enumerable.Empty<string>();
+        public string TrxFilePath { get; set; }
+        public string MarkdownFilePath { get; set; }
+        public string HtmlFilePath { get; set; }
+        public double TestThresholdPercentage { get; set; } = 10;
+    }
+}

--- a/Cake.BenchmarkDotNet/NuGetComparison/CsvReportRecord.cs
+++ b/Cake.BenchmarkDotNet/NuGetComparison/CsvReportRecord.cs
@@ -1,0 +1,42 @@
+﻿using System.Globalization;
+using CsvHelper.Configuration;
+
+namespace Cake.BenchmarkDotNet.NuGetComparison
+{
+    internal class CsvReportRecord
+    {
+        public static string ValueNotAvailable = "?";
+
+        public string Method { get; set; }
+        public string MethodNameSuffix { get; set; }
+        public string Job { get; set; }
+        public string NuGetReferences { get; set; }
+        public string Mean { get; set; }
+        public string Error { get; set; }
+        public string StdDev { get; set; }
+        public string Median { get; set; }
+        public string Ratio { get; set; }
+        public string RatioSD { get; set; }
+        public string Gen0 { get; set; }
+        public string Gen1 { get; set; }
+        public string Allocated { get; set; }
+    }
+
+    internal class CsvReportRecordClassMap : ClassMap<CsvReportRecord>
+    {
+        public CsvReportRecordClassMap()
+        {
+            AutoMap(CultureInfo.InvariantCulture);
+
+            Map(m => m.MethodNameSuffix).Name("methodNameSuffix").Optional().Default(null);
+
+            Map(m => m.Median).Optional().Default(CsvReportRecord.ValueNotAvailable);
+            Map(m => m.Ratio).Optional().Default(CsvReportRecord.ValueNotAvailable);
+            Map(m => m.RatioSD).Optional().Default(CsvReportRecord.ValueNotAvailable);
+
+            Map(m => m.Gen0).Name("Gen 0").Optional().Default(CsvReportRecord.ValueNotAvailable);
+            Map(m => m.Gen1).Name("Gen 1").Optional().Default(CsvReportRecord.ValueNotAvailable);
+            Map(m => m.Allocated).Optional().Default(CsvReportRecord.ValueNotAvailable);
+        }
+    }
+}

--- a/Cake.BenchmarkDotNet/NuGetComparison/NuGetCompareFinalResult.cs
+++ b/Cake.BenchmarkDotNet/NuGetComparison/NuGetCompareFinalResult.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace Cake.BenchmarkDotNet.NuGetComparison
+{
+    public class NuGetCompareFinalResult
+    {
+        public string BaselineVersion { get; }
+        public string BenchmarkVersion { get; }
+        public IEnumerable<NuGetCompareTestResult> TestResults { get; }
+
+        public NuGetCompareFinalResult(
+            string baselineVersion,
+            string benchmarkVersion,
+            IEnumerable<NuGetCompareTestResult> testResults)
+        {
+            BaselineVersion = baselineVersion;
+            BenchmarkVersion = benchmarkVersion;
+            TestResults = testResults;
+        }
+    }
+}

--- a/Cake.BenchmarkDotNet/NuGetComparison/NuGetCompareFinalResult.cs
+++ b/Cake.BenchmarkDotNet/NuGetComparison/NuGetCompareFinalResult.cs
@@ -6,15 +6,18 @@ namespace Cake.BenchmarkDotNet.NuGetComparison
     {
         public string BaselineVersion { get; }
         public string BenchmarkVersion { get; }
+        public double TestThresholdPercentage { get; }
         public IEnumerable<NuGetCompareTestResult> TestResults { get; }
 
         public NuGetCompareFinalResult(
             string baselineVersion,
             string benchmarkVersion,
+            double testThresholdPercentage,
             IEnumerable<NuGetCompareTestResult> testResults)
         {
             BaselineVersion = baselineVersion;
             BenchmarkVersion = benchmarkVersion;
+            TestThresholdPercentage = testThresholdPercentage;
             TestResults = testResults;
         }
     }

--- a/Cake.BenchmarkDotNet/NuGetComparison/NuGetCompareTestResult.cs
+++ b/Cake.BenchmarkDotNet/NuGetComparison/NuGetCompareTestResult.cs
@@ -1,0 +1,42 @@
+﻿using Perfolizer.Mathematics.SignificanceTesting;
+
+namespace Cake.BenchmarkDotNet.NuGetComparison
+{
+    public class NuGetCompareTestResult
+    {
+        public string BaselineVersion { get; }
+        public string BenchmarkVersion { get; }
+        public string RuntimeName { get; }
+        public EquivalenceTestConclusion Conclusion { get; }
+        public string ClassName { get; }
+        public string NamespaceName { get; }
+        public string MethodName { get; }
+        public double SpeedDifferencePercentage { get; }
+        public double BaselineMedianSpeedNs { get; }
+        public double BenchmarkMedianSpeedNs { get; }
+
+        public NuGetCompareTestResult(
+            string baselineVersion,
+            string benchmarkVersion,
+            string runtimeName,
+            EquivalenceTestConclusion conclusion,
+            string className,
+            string namespaceName,
+            string methodName,
+            double speedDifferencePercentage,
+            double baselineMedianSpeedNs,
+            double benchmarkMedianSpeedNs)
+        {
+            BaselineVersion = baselineVersion;
+            BenchmarkVersion = benchmarkVersion;
+            RuntimeName = runtimeName;
+            Conclusion = conclusion;
+            ClassName = className;
+            NamespaceName = namespaceName;
+            MethodName = methodName;
+            SpeedDifferencePercentage = speedDifferencePercentage;
+            BaselineMedianSpeedNs = baselineMedianSpeedNs;
+            BenchmarkMedianSpeedNs = benchmarkMedianSpeedNs;
+        }
+    }
+}

--- a/Cake.BenchmarkDotNet/NuGetComparison/NuGetComparer.cs
+++ b/Cake.BenchmarkDotNet/NuGetComparison/NuGetComparer.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using CsvHelper;
+using Perfolizer.Mathematics.SignificanceTesting;
+
+namespace Cake.BenchmarkDotNet.NuGetComparison
+{
+    public class NuGetComparer
+    {
+        private static readonly Regex testClassNameRegex = new Regex(@"-report.[Cc][Ss][Vv]$", RegexOptions.Compiled);
+
+        private readonly double _testThresholdPercentage;
+
+        public NuGetComparer(double testThresholdPercentage)
+        {
+            _testThresholdPercentage = testThresholdPercentage;
+        }
+
+        public NuGetCompareFinalResult Compare(string benchmarkDotNetArtifactsDirectory, IEnumerable<string> filterPatterns)
+        {
+            var compareTestResults = new List<NuGetCompareTestResult>();
+            var filters = filterPatterns.Select(pattern => new Regex(WildcardToRegex(pattern), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)).ToArray();
+
+            var runtimeDirectories = GetRuntimesDirectories(benchmarkDotNetArtifactsDirectory);
+            foreach (var runtimeDirectory in runtimeDirectories)
+            {
+                var runtimeName = new DirectoryInfo(runtimeDirectory).Name;
+                var csvReportFilePaths = GetCsvReportFilePaths(runtimeDirectory);
+                foreach (var csvReportFilePath in csvReportFilePaths)
+                {
+                    var testClassName = testClassNameRegex.Replace(new FileInfo(csvReportFilePath).Name, string.Empty);
+
+                    using var csvReportFileStreamReader = new StreamReader(csvReportFilePath);
+                    using var csvReader = new CsvReader(csvReportFileStreamReader, CultureInfo.InvariantCulture);
+                    csvReader.Context.RegisterClassMap<CsvReportRecordClassMap>();
+
+                    var csvReportRecordsGroups = csvReader.GetRecords<CsvReportRecord>()
+                        .Where(record => !filters.Any() || filters.Any(filter => filter.IsMatch(testClassName)))
+                        .GroupBy(record =>
+                            !string.IsNullOrWhiteSpace(record.MethodNameSuffix)
+                            && record.MethodNameSuffix != "?"
+                            ? $"{record.Method}[{record.MethodNameSuffix}]"
+                            : record.Method)
+                        .ToList();
+
+                    foreach (var csvReportRecordsGroup in csvReportRecordsGroups)
+                    {
+                        compareTestResults.Add(
+                            CompareBenchmarkToBaseline(
+                                testClassName,
+                                runtimeName,
+                                _testThresholdPercentage,
+                                csvReportRecordsGroup));
+                    }
+                }
+            }
+            
+            return new NuGetCompareFinalResult(
+                compareTestResults?[0].BaselineVersion ?? "Unknown",
+                compareTestResults?[0].BenchmarkVersion ?? "Unknown",
+                compareTestResults);
+        }
+
+        // https://stackoverflow.com/a/6907849/5852046 not perfect but should work for all we need
+        private static string WildcardToRegex(string pattern) => $"^{Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".")}$";
+
+        private static string[] GetRuntimesDirectories(string benchmarkDotNetArtifactsDirectory) =>
+            Directory.GetDirectories(Path.GetFullPath(benchmarkDotNetArtifactsDirectory));
+
+        private static IEnumerable<string> GetCsvReportFilePaths(string runtimeDirectory) =>
+            Directory.GetFiles(Path.Combine(runtimeDirectory, "results"))
+                .Where(filePath => filePath.ToLower().EndsWith(".csv"));
+
+        private static NuGetCompareTestResult CompareBenchmarkToBaseline(
+            string testClassName,
+            string runtimeName,
+            double testThresholdPercentage,
+            IGrouping<string, CsvReportRecord> csvReportRecordsGroup)
+        {
+            var baselineRecord = csvReportRecordsGroup.Single(record => record.Job == "BASELINE");
+            var benchmarkRecord = csvReportRecordsGroup.Single(record => record.Job == "BENCHMARK");
+
+            var classNameSeparatorIndex = testClassName.LastIndexOf(".");
+            var namespaceName = testClassName.Substring(0, classNameSeparatorIndex);
+            var className = testClassName.Substring(classNameSeparatorIndex + 1);
+            var methodName = csvReportRecordsGroup.Key;
+
+            var speedDifferencePercentage = benchmarkRecord.Ratio != CsvReportRecord.ValueNotAvailable
+                ? double.Parse(benchmarkRecord.Ratio.Contains("%") ? benchmarkRecord.Ratio.TrimEnd('%') : benchmarkRecord.Ratio) / 100
+                : double.NaN;
+            var baselineMedianSpeedNs = baselineRecord.Median != CsvReportRecord.ValueNotAvailable
+                ? double.Parse(baselineRecord.Median.Contains(" ") ? baselineRecord.Median.Split(" ").First() : baselineRecord.Median)
+                : double.NaN;
+            var benchmarkMedianSpeedNs = benchmarkRecord.Median != CsvReportRecord.ValueNotAvailable
+                ? double.Parse(benchmarkRecord.Median.Contains(" ") ? benchmarkRecord.Median.Split(" ").First() : benchmarkRecord.Median)
+                : double.NaN;
+
+            var testThresholdPercentageAsRawValue = testThresholdPercentage / 100;
+
+            var conclusion = speedDifferencePercentage != double.NaN
+                ? Math.Abs(speedDifferencePercentage) <= testThresholdPercentageAsRawValue
+                    ? EquivalenceTestConclusion.Same
+                    : speedDifferencePercentage > 0
+                        ? EquivalenceTestConclusion.Slower
+                        : speedDifferencePercentage < 0
+                            ? EquivalenceTestConclusion.Faster
+                            : EquivalenceTestConclusion.Same
+                : EquivalenceTestConclusion.Unknown;
+
+            return new NuGetCompareTestResult(
+                baselineRecord.NuGetReferences,
+                benchmarkRecord.NuGetReferences,
+                runtimeName,
+                conclusion,
+                className,
+                namespaceName,
+                methodName,
+                speedDifferencePercentage,
+                baselineMedianSpeedNs,
+                benchmarkMedianSpeedNs);
+        }
+    }
+}

--- a/Cake.BenchmarkDotNet/NuGetComparison/NuGetComparer.cs
+++ b/Cake.BenchmarkDotNet/NuGetComparison/NuGetComparer.cs
@@ -20,7 +20,7 @@ namespace Cake.BenchmarkDotNet.NuGetComparison
             _testThresholdPercentage = testThresholdPercentage;
         }
 
-        public NuGetCompareFinalResult Compare(string benchmarkDotNetArtifactsDirectory, IEnumerable<string> filterPatterns)
+        public NuGetCompareFinalResult Compare(string benchmarkDotNetArtifactsDirectory, double testThresholdPercentage, IEnumerable<string> filterPatterns)
         {
             var compareTestResults = new List<NuGetCompareTestResult>();
             var filters = filterPatterns.Select(pattern => new Regex(WildcardToRegex(pattern), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)).ToArray();
@@ -62,6 +62,7 @@ namespace Cake.BenchmarkDotNet.NuGetComparison
             return new NuGetCompareFinalResult(
                 compareTestResults?[0].BaselineVersion ?? "Unknown",
                 compareTestResults?[0].BenchmarkVersion ?? "Unknown",
+                testThresholdPercentage,
                 compareTestResults);
         }
 

--- a/Cake.BenchmarkDotNet/Printers/Html/HtmlPrinter.cs
+++ b/Cake.BenchmarkDotNet/Printers/Html/HtmlPrinter.cs
@@ -111,7 +111,7 @@ namespace Cake.BenchmarkDotNet.Printers.Html
                 .ToHtml();
 
             var runtimesSummaryReportBody = @$"
-                {GetHtmlPageHeader(nuGetCompareFinalResult.BaselineVersion, nuGetCompareFinalResult.BenchmarkVersion)}
+                {GetHtmlPageHeader(nuGetCompareFinalResult.BaselineVersion, nuGetCompareFinalResult.BenchmarkVersion, nuGetCompareFinalResult.TestThresholdPercentage)}
                 {runtimesSummaryTable}
             ";
 
@@ -140,7 +140,7 @@ namespace Cake.BenchmarkDotNet.Printers.Html
                     .ToHtml();
 
                 var testClassesSummaryReportBody = @$"
-                    {GetHtmlPageHeader(nuGetCompareFinalResult.BaselineVersion, nuGetCompareFinalResult.BenchmarkVersion)}
+                    {GetHtmlPageHeader(nuGetCompareFinalResult.BaselineVersion, nuGetCompareFinalResult.BenchmarkVersion, nuGetCompareFinalResult.TestThresholdPercentage)}
                     <p><b>Runtime:</b> {runtime.Key}</p>
                     {testClassesSummaryTable}
                 ";
@@ -198,7 +198,7 @@ namespace Cake.BenchmarkDotNet.Printers.Html
                         .ToHtml();
 
                     var testClassSummaryReportBody = @$"
-                        {GetHtmlPageHeader(nuGetCompareFinalResult.BaselineVersion, nuGetCompareFinalResult.BenchmarkVersion)}
+                        {GetHtmlPageHeader(nuGetCompareFinalResult.BaselineVersion, nuGetCompareFinalResult.BenchmarkVersion, nuGetCompareFinalResult.TestThresholdPercentage)}
                         <p><b>Runtime:</b> {runtime.Key} &#8594 <b>TestClass:</b> {tests.Key}</p>
                         <h2>Slower Tests (focus on these)</h2>
                         {slowerTestsTable}
@@ -239,11 +239,11 @@ namespace Cake.BenchmarkDotNet.Printers.Html
 
         private const string Template = @"<head><link rel=""stylesheet"" type=""text/css"" href=""{0}report_style.css""></head><body>{1}</body>";
 
-        private static string GetHtmlPageHeader(string baselineVersion, string benchmarkVersion) =>
+        private static string GetHtmlPageHeader(string baselineVersion, string benchmarkVersion, double testThresholdPercentage) =>
             @$"
                 <h1>Perfomance Test Results ({DateTime.UtcNow} UTC)</h1>
                 <p><b>Baseline:</b> {baselineVersion}</p>
-                <p><b>Benchmark:</b> {(benchmarkVersion.ToLower() == "default" ? "Current Source Code" : benchmarkVersion)}</p>
+                <p><b>Benchmark:</b> {(benchmarkVersion.ToLower() == "default" ? "Current Source Code" : benchmarkVersion)} (<b>Test Threshold:</b> {testThresholdPercentage}%)</p>
             ";
     }
 }

--- a/Cake.BenchmarkDotNet/Printers/Html/HtmlPrinter.cs
+++ b/Cake.BenchmarkDotNet/Printers/Html/HtmlPrinter.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Web;
 using Cake.BenchmarkDotNet.Dto;
+using Cake.BenchmarkDotNet.NuGetComparison;
 using MarkdownLog;
 using Perfolizer.Mathematics.SignificanceTesting;
 
@@ -83,6 +85,137 @@ namespace Cake.BenchmarkDotNet.Printers.Html
             }
         }
 
+        public void Print(NuGetCompareFinalResult nuGetCompareFinalResult, string outputPath)
+        {
+            if (outputPath == null)
+                return;
+
+            var runtimes = nuGetCompareFinalResult.TestResults
+                .GroupBy(x => x.RuntimeName)
+                .ToArray();
+
+            var runtimesSummaryTable = runtimes
+                .Select(x => new
+                {
+                    Runtime = $"[{x.Key}]({HttpUtility.UrlPathEncode(x.Key)}/index.html)",
+                    Slower = x.Count(t => t.Conclusion == EquivalenceTestConclusion.Slower),
+                    Same = x.Count(t => t.Conclusion == EquivalenceTestConclusion.Same),
+                    Faster = x.Count(t => t.Conclusion == EquivalenceTestConclusion.Faster),
+                    Errors = x.Count(t => t.Conclusion == EquivalenceTestConclusion.Unknown),
+                })
+                .OrderByDescending(x => x.Errors)
+                .ThenByDescending(x => x.Slower)
+                .ThenBy(x => x.Runtime)
+                .ToMarkdownTable()
+                .WithHeaders("Runtime", "Slower", "Same", "Faster", "Errors")
+                .ToHtml();
+
+            var runtimesSummaryReportBody = @$"
+                {GetHtmlPageHeader(nuGetCompareFinalResult.BaselineVersion, nuGetCompareFinalResult.BenchmarkVersion)}
+                {runtimesSummaryTable}
+            ";
+
+            File.WriteAllText(Path.Combine(outputPath, "index.html"), string.Format(Template, "./", runtimesSummaryReportBody));
+
+            foreach (var runtime in runtimes)
+            {
+                var testGroups = runtime
+                    .GroupBy(x => $"{x.NamespaceName}.{x.ClassName}")
+                    .ToArray();
+
+                var testClassesSummaryTable = testGroups
+                    .Select(x => new
+                    {
+                        Class = $"[{x.Key}]({HttpUtility.UrlPathEncode(x.Key)}.html)",
+                        Slower = x.Count(t => t.Conclusion == EquivalenceTestConclusion.Slower),
+                        Same = x.Count(t => t.Conclusion == EquivalenceTestConclusion.Same),
+                        Faster = x.Count(t => t.Conclusion == EquivalenceTestConclusion.Faster),
+                        Errors = x.Count(t => t.Conclusion == EquivalenceTestConclusion.Unknown),
+                    })
+                    .OrderByDescending(x => x.Errors)
+                    .ThenByDescending(x => x.Slower)
+                    .ThenBy(x => x.Class)
+                    .ToMarkdownTable()
+                    .WithHeaders("Class", "Slower", "Same", "Faster", "Errors")
+                    .ToHtml();
+
+                var testClassesSummaryReportBody = @$"
+                    {GetHtmlPageHeader(nuGetCompareFinalResult.BaselineVersion, nuGetCompareFinalResult.BenchmarkVersion)}
+                    <p><b>Runtime:</b> {runtime.Key}</p>
+                    {testClassesSummaryTable}
+                ";
+
+                var runtimePath = Path.Combine(outputPath, runtime.Key);
+                Directory.CreateDirectory(runtimePath);
+                File.WriteAllText(Path.Combine(runtimePath, "index.html"), string.Format(Template, "../", testClassesSummaryReportBody));
+
+                foreach (var tests in testGroups)
+                {
+                    var slowerTestsTable = tests
+                        .Where(x => x.Conclusion == EquivalenceTestConclusion.Slower)
+                        .OrderByDescending(x => x.SpeedDifferencePercentage)
+                        .ThenBy(x => x.MethodName)
+                        .Select(x => new
+                        {
+                            TestName = x.MethodName,
+                            Ratio = $"{Math.Round(Math.Abs(x.SpeedDifferencePercentage) * 100, 2)}%",
+                            BaseMedian = x.BaselineMedianSpeedNs,
+                            DiffMedian = x.BenchmarkMedianSpeedNs,
+                        })
+                        .ToMarkdownTable()
+                        .WithHeaders("Test Name", "% Slower", "Base Median (ns)", "Benchmark Median (ns)")
+                        .ToHtml();
+
+                    var fasterTestsTable = tests
+                        .Where(x => x.Conclusion == EquivalenceTestConclusion.Faster)
+                        .OrderBy(x => x.SpeedDifferencePercentage)
+                        .ThenBy(x => x.MethodName)
+                        .Select(x => new
+                        {
+                            TestName = x.MethodName,
+                            Ratio = $"{Math.Round(Math.Abs(x.SpeedDifferencePercentage) * 100, 2)}%",
+                            BaseMedian = x.BaselineMedianSpeedNs,
+                            DiffMedian = x.BenchmarkMedianSpeedNs,
+                        })
+                        .ToMarkdownTable()
+                        .WithHeaders("Test Name", "% Faster", "Base Median (ns)", "Benchmark Median (ns)")
+                        .ToHtml();
+
+                    var otherTestsTable = tests
+                        .Where(x => x.Conclusion != EquivalenceTestConclusion.Slower && x.Conclusion != EquivalenceTestConclusion.Faster)
+                        .OrderByDescending(x => x.SpeedDifferencePercentage)
+                        .ThenBy(x => x.MethodName)
+                        .Select(x => new
+                        {
+                            Conclusion = x.Conclusion == EquivalenceTestConclusion.Same ? $"{EquivalenceTestConclusion.Same} (within threshold)" : x.Conclusion.ToString(),
+                            TestName = x.MethodName,
+                            Ratio = $"{Math.Round(Math.Abs(x.SpeedDifferencePercentage) * 100, 2)}% {(x.SpeedDifferencePercentage < 0 ? "faster" : "slower" )}",
+                            BaseMedian = x.BaselineMedianSpeedNs,
+                            DiffMedian = x.BenchmarkMedianSpeedNs,
+                        })
+                        .ToMarkdownTable()
+                        .WithHeaders("Conclusion", "Test Name", "% Difference", "Base Median (ns)", "Benchmark Median (ns)")
+                        .ToHtml();
+
+                    var testClassSummaryReportBody = @$"
+                        {GetHtmlPageHeader(nuGetCompareFinalResult.BaselineVersion, nuGetCompareFinalResult.BenchmarkVersion)}
+                        <p><b>Runtime:</b> {runtime.Key} &#8594 <b>TestClass:</b> {tests.Key}</p>
+                        <h2>Slower Tests (focus on these)</h2>
+                        {slowerTestsTable}
+                        <br />
+                        <h2>Faster Tests</h2>
+                        {fasterTestsTable}
+                        <br />
+                        <h2>Other Tests</h2>
+                        {otherTestsTable}
+                        <br />
+                    ";
+
+                    File.WriteAllText(Path.Combine(runtimePath, $"{tests.Key}.html"), string.Format(Template, "../", testClassSummaryReportBody));
+                }
+            }
+        }
+
         private string GetRatio(EquivalenceTestConclusion conclusion, Benchmark baseResult, Benchmark diffResult)
         {
             if (conclusion == EquivalenceTestConclusion.Same)
@@ -105,5 +238,12 @@ namespace Cake.BenchmarkDotNet.Printers.Html
         }
 
         private const string Template = @"<head><link rel=""stylesheet"" type=""text/css"" href=""{0}report_style.css""></head><body>{1}</body>";
+
+        private static string GetHtmlPageHeader(string baselineVersion, string benchmarkVersion) =>
+            @$"
+                <h1>Perfomance Test Results ({DateTime.UtcNow} UTC)</h1>
+                <p><b>Baseline:</b> {baselineVersion}</p>
+                <p><b>Benchmark:</b> {(benchmarkVersion.ToLower() == "default" ? "Current Source Code" : benchmarkVersion)}</p>
+            ";
     }
 }

--- a/Cake.BenchmarkDotNet/Printers/IPrinter.cs
+++ b/Cake.BenchmarkDotNet/Printers/IPrinter.cs
@@ -1,9 +1,12 @@
 ﻿using System.Collections.Generic;
+using Cake.BenchmarkDotNet.NuGetComparison;
 
 namespace Cake.BenchmarkDotNet.Printers
 {
     public interface IPrinter
     {
         void Print(IEnumerable<CompareResult> results, string outputPath);
+
+        void Print(NuGetCompareFinalResult nuGetCompareFinalResult, string outputPath);
     }
 }

--- a/Cake.BenchmarkDotNet/Printers/Markdown/MarkdownPrinter.cs
+++ b/Cake.BenchmarkDotNet/Printers/Markdown/MarkdownPrinter.cs
@@ -41,7 +41,7 @@ namespace Cake.BenchmarkDotNet.Printers.Markdown
 
             var reportHeader = $"# Perfomance Test Results ({DateTime.UtcNow} UTC){Environment.NewLine}{Environment.NewLine}"
                 + $"**Baseline:** {nuGetCompareFinalResult.BaselineVersion}{Environment.NewLine}{Environment.NewLine}"
-                + $"**Benchmark:** {(nuGetCompareFinalResult.BenchmarkVersion.ToLower() == "default" ? "Current Source Code" : nuGetCompareFinalResult.BenchmarkVersion)}{Environment.NewLine}{Environment.NewLine}";
+                + $"**Benchmark:** {(nuGetCompareFinalResult.BenchmarkVersion.ToLower() == "default" ? "Current Source Code" : nuGetCompareFinalResult.BenchmarkVersion)} (**Test Threshold:** {nuGetCompareFinalResult.TestThresholdPercentage}%){Environment.NewLine}{Environment.NewLine}";
 
             var slowerResultsTable = nuGetCompareFinalResult.TestResults
                 .Where(x => x.Conclusion == EquivalenceTestConclusion.Slower)

--- a/Cake.BenchmarkDotNet/Printers/Markdown/MarkdownPrinter.cs
+++ b/Cake.BenchmarkDotNet/Printers/Markdown/MarkdownPrinter.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Cake.BenchmarkDotNet.Dto;
+using Cake.BenchmarkDotNet.NuGetComparison;
 using MarkdownLog;
 using Perfolizer.Mathematics.SignificanceTesting;
 
@@ -32,6 +32,72 @@ namespace Cake.BenchmarkDotNet.Printers.Markdown
                 .ToMarkdown();
 
             File.WriteAllText(outputPath, report);
+        }
+
+        public void Print(NuGetCompareFinalResult nuGetCompareFinalResult, string outputPath)
+        {
+            if (outputPath == null)
+                return;
+
+            var reportHeader = $"# Perfomance Test Results ({DateTime.UtcNow} UTC){Environment.NewLine}{Environment.NewLine}"
+                + $"**Baseline:** {nuGetCompareFinalResult.BaselineVersion}{Environment.NewLine}{Environment.NewLine}"
+                + $"**Benchmark:** {(nuGetCompareFinalResult.BenchmarkVersion.ToLower() == "default" ? "Current Source Code" : nuGetCompareFinalResult.BenchmarkVersion)}{Environment.NewLine}{Environment.NewLine}";
+
+            var slowerResultsTable = nuGetCompareFinalResult.TestResults
+                .Where(x => x.Conclusion == EquivalenceTestConclusion.Slower)
+                .OrderByDescending(x => x.SpeedDifferencePercentage)
+                .ThenBy(x => $"{x.NamespaceName}.{x.ClassName}.{x.MethodName}")
+                .Select(x => new
+                {
+                    TestName = $"{x.NamespaceName}.{x.ClassName}.{x.MethodName} ({x.RuntimeName})",
+                    Ratio = $"{Math.Round(Math.Abs(x.SpeedDifferencePercentage) * 100, 2)}%",
+                    BaseMedian = x.BaselineMedianSpeedNs,
+                    DiffMedian = x.BenchmarkMedianSpeedNs,
+                })
+                .ToMarkdownTable()
+                .WithHeaders("Test Name", "% Slower", "Baseline Median (ns)", "Benchmark Median (ns)")
+                .ToMarkdown();
+
+            var fasterTestsTable = nuGetCompareFinalResult.TestResults
+                .Where(x => x.Conclusion == EquivalenceTestConclusion.Faster)
+                .OrderBy(x => x.SpeedDifferencePercentage)
+                .ThenBy(x => $"{x.NamespaceName}.{x.ClassName}.{x.MethodName}")
+                .Select(x => new
+                {
+                    TestName = $"{x.NamespaceName}.{x.ClassName}.{x.MethodName} ({x.RuntimeName})",
+                    Ratio = $"{Math.Round(Math.Abs(x.SpeedDifferencePercentage) * 100, 2)}%",
+                    BaseMedian = x.BaselineMedianSpeedNs,
+                    DiffMedian = x.BenchmarkMedianSpeedNs,
+                })
+                .ToMarkdownTable()
+                .WithHeaders("Test Name", "% Faster", "Base Median (ns)", "Benchmark Median (ns)")
+                .ToMarkdown();
+
+            var otherTestsTable = nuGetCompareFinalResult.TestResults
+                .Where(x => x.Conclusion != EquivalenceTestConclusion.Slower && x.Conclusion != EquivalenceTestConclusion.Faster)
+                .OrderByDescending(x => x.SpeedDifferencePercentage)
+                .ThenBy(x => $"{x.NamespaceName}.{x.ClassName}.{x.MethodName}")
+                .Select(x => new
+                {
+                    Conclusion = x.Conclusion == EquivalenceTestConclusion.Same ? $"{EquivalenceTestConclusion.Same} (within threshold)" : x.Conclusion.ToString(),
+                    TestName = $"{x.NamespaceName}.{x.ClassName}.{x.MethodName} ({x.RuntimeName})",
+                    Ratio = $"{Math.Round(Math.Abs(x.SpeedDifferencePercentage) * 100, 2)}% {(x.SpeedDifferencePercentage < 0 ? "faster" : "slower")}",
+                    BaseMedian = x.BaselineMedianSpeedNs,
+                    DiffMedian = x.BenchmarkMedianSpeedNs,
+                })
+                .ToMarkdownTable()
+                .WithHeaders("Conclusion", "Test Name", "% Difference", "Base Median (ns)", "Benchmark Median (ns)")
+                .ToMarkdown();
+
+            var reportBody = $"{reportHeader}"
+                + $"## Slower Tests (focus on these){Environment.NewLine}{Environment.NewLine}"
+                + $"{slowerResultsTable}{Environment.NewLine}"
+                + $"## Faster Tests{Environment.NewLine}{Environment.NewLine}"
+                + $"{fasterTestsTable}{Environment.NewLine}"
+                + $"## Other Tests{Environment.NewLine}{Environment.NewLine}"
+                + $"{otherTestsTable}{Environment.NewLine}";
+
+            File.WriteAllText(outputPath, reportBody);
         }
 
         private string GetRatio(EquivalenceTestConclusion conclusion, Benchmark baseResult, Benchmark diffResult)

--- a/Cake.BenchmarkDotnet.Tests/Cake.BenchmarkDotnet.Tests.csproj
+++ b/Cake.BenchmarkDotnet.Tests/Cake.BenchmarkDotnet.Tests.csproj
@@ -8,7 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
* Added new `BenchmarkDotNetCompareNuGetResults` Cake method.
* This allows for comparing the results from the new NuGet package version performance testing approach.